### PR TITLE
Fix repeatingly render QRCodes

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -2,6 +2,8 @@
 Template.qrcode.onRendered(function(){
 	this.autorun(()=> {
 		let options = Template.currentData();
-		this.$(".qrcode").qrcode(options);
+		var qr = this.$(".qrcode");
+		qr.html("");
+		qr.qrcode(options);
 	})
 });


### PR DESCRIPTION
Fix repeatingly render QRCodes. Should clean the DOM as well as existing QRCode before rendering a new QRCode.
